### PR TITLE
MiddlewareにThrottleRequestを追加する。

### DIFF
--- a/app/Http/Middleware/ThrottleRequests.php
+++ b/app/Http/Middleware/ThrottleRequests.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace Illuminate\Routing\Middleware;
+
+use Closure;
+use RuntimeException;
+use Illuminate\Support\Str;
+use Illuminate\Cache\RateLimiter;
+use Illuminate\Support\InteractsWithTime;
+use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Http\Exceptions\ThrottleRequestsException;
+
+class ThrottleRequests
+{
+    use InteractsWithTime;
+
+    /**
+     * The rate limiter instance.
+     *
+     * @var \Illuminate\Cache\RateLimiter
+     */
+    protected $limiter;
+
+    /**
+     * Create a new request throttler.
+     *
+     * @param  \Illuminate\Cache\RateLimiter  $limiter
+     * @return void
+     */
+    public function __construct(RateLimiter $limiter)
+    {
+        $this->limiter = $limiter;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  int|string  $maxAttempts
+     * @param  float|int  $decayMinutes
+     * @return mixed
+     * @throws \Illuminate\Http\Exceptions\ThrottleRequestsException
+     */
+    public function handle($request, Closure $next, $maxAttempts = 60, $decayMinutes = 1)
+    {
+        $key = $this->resolveRequestSignature($request);
+
+        $maxAttempts = $this->resolveMaxAttempts($request, $maxAttempts);
+
+        if ($this->limiter->tooManyAttempts($key, $maxAttempts)) {
+            throw $this->buildException($key, $maxAttempts);
+        }
+
+        $this->limiter->hit($key, $decayMinutes);
+
+        $response = $next($request);
+
+        return $this->addHeaders(
+            $response, $maxAttempts,
+            $this->calculateRemainingAttempts($key, $maxAttempts)
+        );
+    }
+
+    /**
+     * Resolve the number of attempts if the user is authenticated or not.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int|string  $maxAttempts
+     * @return int
+     */
+    protected function resolveMaxAttempts($request, $maxAttempts)
+    {
+        if (Str::contains($maxAttempts, '|')) {
+            $maxAttempts = explode('|', $maxAttempts, 2)[$request->user() ? 1 : 0];
+        }
+
+        if (! is_numeric($maxAttempts) && $request->user()) {
+            $maxAttempts = $request->user()->{$maxAttempts};
+        }
+
+        return (int) $maxAttempts;
+    }
+
+    /**
+     * Resolve request signature.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return string
+     * @throws \RuntimeException
+     */
+    protected function resolveRequestSignature($request)
+    {
+        if ($user = $request->user()) {
+            return sha1($user->getAuthIdentifier());
+        }
+
+        if ($route = $request->route()) {
+            return sha1($route->getDomain().'|'.$request->ip());
+        }
+
+        throw new RuntimeException('Unable to generate the request signature. Route unavailable.');
+    }
+
+    /**
+     * Create a 'too many attempts' exception.
+     *
+     * @param  string  $key
+     * @param  int  $maxAttempts
+     * @return \Illuminate\Http\Exceptions\ThrottleRequestsException
+     */
+    protected function buildException($key, $maxAttempts)
+    {
+        $retryAfter = $this->getTimeUntilNextRetry($key);
+
+        $headers = $this->getHeaders(
+            $maxAttempts,
+            $this->calculateRemainingAttempts($key, $maxAttempts, $retryAfter),
+            $retryAfter
+        );
+
+        return new ThrottleRequestsException(
+            'Too Many Attempts.', null, $headers
+        );
+    }
+
+    /**
+     * Get the number of seconds until the next retry.
+     *
+     * @param  string  $key
+     * @return int
+     */
+    protected function getTimeUntilNextRetry($key)
+    {
+        return $this->limiter->availableIn($key);
+    }
+
+    /**
+     * Add the limit header information to the given response.
+     *
+     * @param  \Symfony\Component\HttpFoundation\Response  $response
+     * @param  int  $maxAttempts
+     * @param  int  $remainingAttempts
+     * @param  int|null  $retryAfter
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    protected function addHeaders(Response $response, $maxAttempts, $remainingAttempts, $retryAfter = null)
+    {
+        $response->headers->add(
+            $this->getHeaders($maxAttempts, $remainingAttempts, $retryAfter)
+        );
+
+        return $response;
+    }
+
+    /**
+     * Get the limit headers information.
+     *
+     * @param  int  $maxAttempts
+     * @param  int  $remainingAttempts
+     * @param  int|null  $retryAfter
+     * @return array
+     */
+    protected function getHeaders($maxAttempts, $remainingAttempts, $retryAfter = null)
+    {
+        $headers = [
+            'X-RateLimit-Limit' => $maxAttempts,
+            'X-RateLimit-Remaining' => $remainingAttempts,
+        ];
+
+        if (! is_null($retryAfter)) {
+            $headers['Retry-After'] = $retryAfter;
+            $headers['X-RateLimit-Reset'] = $this->availableAt($retryAfter);
+        }
+
+        return $headers;
+    }
+
+    /**
+     * Calculate the number of remaining attempts.
+     *
+     * @param  string  $key
+     * @param  int  $maxAttempts
+     * @param  int|null  $retryAfter
+     * @return int
+     */
+    protected function calculateRemainingAttempts($key, $maxAttempts, $retryAfter = null)
+    {
+        if (is_null($retryAfter)) {
+            return $this->limiter->retriesLeft($key, $maxAttempts);
+        }
+
+        return 0;
+    }
+}

--- a/app/Http/Middleware/ThrottleRequests.php
+++ b/app/Http/Middleware/ThrottleRequests.php
@@ -1,6 +1,7 @@
 <?php
 
-namespace Illuminate\Routing\Middleware;
+//namespace Illuminate\Routing\Middleware;
+namespace App\Http\Middleware;
 
 use Closure;
 use RuntimeException;

--- a/app/Http/Middleware/ThrottleRequests.php
+++ b/app/Http/Middleware/ThrottleRequests.php
@@ -1,196 +1,117 @@
 <?php
-
-//namespace Illuminate\Routing\Middleware;
 namespace App\Http\Middleware;
-
 use Closure;
-use RuntimeException;
-use Illuminate\Support\Str;
+use Illuminate\Http\Response;
 use Illuminate\Cache\RateLimiter;
-use Illuminate\Support\InteractsWithTime;
-use Symfony\Component\HttpFoundation\Response;
-use Illuminate\Http\Exceptions\ThrottleRequestsException;
-
+use Symfony\Component\HttpFoundation\JsonResponse;
 class ThrottleRequests
 {
-    use InteractsWithTime;
-
     /**
      * The rate limiter instance.
      *
      * @var \Illuminate\Cache\RateLimiter
      */
     protected $limiter;
-
     /**
      * Create a new request throttler.
      *
-     * @param  \Illuminate\Cache\RateLimiter  $limiter
+     * @param  \Illuminate\Cache\RateLimiter $limiter
+     *
      * @return void
      */
     public function __construct(RateLimiter $limiter)
     {
         $this->limiter = $limiter;
     }
-
     /**
      * Handle an incoming request.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure  $next
-     * @param  int|string  $maxAttempts
-     * @param  float|int  $decayMinutes
+     * @param  \Illuminate\Http\Request $request
+     * @param  \Closure                 $next
+     * @param  int                      $maxAttempts
+     * @param  int                      $decayMinutes
+     *
      * @return mixed
-     * @throws \Illuminate\Http\Exceptions\ThrottleRequestsException
      */
     public function handle($request, Closure $next, $maxAttempts = 60, $decayMinutes = 1)
     {
         $key = $this->resolveRequestSignature($request);
-
-        $maxAttempts = $this->resolveMaxAttempts($request, $maxAttempts);
-
-        if ($this->limiter->tooManyAttempts($key, $maxAttempts)) {
-            throw $this->buildException($key, $maxAttempts);
+        if ($this->limiter->tooManyAttempts($key, $maxAttempts, $decayMinutes)) {
+            return $this->buildResponse($key, $maxAttempts);
         }
-
         $this->limiter->hit($key, $decayMinutes);
-
         $response = $next($request);
-
         return $this->addHeaders(
-            $response, $maxAttempts,
+            $response,
+            $maxAttempts,
             $this->calculateRemainingAttempts($key, $maxAttempts)
         );
     }
-
-    /**
-     * Resolve the number of attempts if the user is authenticated or not.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  int|string  $maxAttempts
-     * @return int
-     */
-    protected function resolveMaxAttempts($request, $maxAttempts)
-    {
-        if (Str::contains($maxAttempts, '|')) {
-            $maxAttempts = explode('|', $maxAttempts, 2)[$request->user() ? 1 : 0];
-        }
-
-        if (! is_numeric($maxAttempts) && $request->user()) {
-            $maxAttempts = $request->user()->{$maxAttempts};
-        }
-
-        return (int) $maxAttempts;
-    }
-
     /**
      * Resolve request signature.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Http\Request $request
+     *
      * @return string
-     * @throws \RuntimeException
      */
     protected function resolveRequestSignature($request)
     {
-        if ($user = $request->user()) {
-            return sha1($user->getAuthIdentifier());
-        }
-
-        if ($route = $request->route()) {
-            return sha1($route->getDomain().'|'.$request->ip());
-        }
-
-        throw new RuntimeException('Unable to generate the request signature. Route unavailable.');
+        return sha1(
+            $request->method() .
+            '|' . $request->getHost() .
+            '|' . $request->ip()
+        );
     }
-
     /**
-     * Create a 'too many attempts' exception.
+     * Create a 'too many attempts' response.
      *
-     * @param  string  $key
-     * @param  int  $maxAttempts
-     * @return \Illuminate\Http\Exceptions\ThrottleRequestsException
+     * @param  string $key
+     * @param  int    $maxAttempts
+     *
+     * @return \Illuminate\Http\Response
      */
-    protected function buildException($key, $maxAttempts)
+    protected function buildResponse($key, $maxAttempts)
     {
-        $retryAfter = $this->getTimeUntilNextRetry($key);
-
-        $headers = $this->getHeaders(
+        $response = new JsonResponse(['status' => 429, 'message' => 'Too Many Attempts.'], 429);
+        return $this->addHeaders(
+            $response,
             $maxAttempts,
-            $this->calculateRemainingAttempts($key, $maxAttempts, $retryAfter),
-            $retryAfter
-        );
-
-        return new ThrottleRequestsException(
-            'Too Many Attempts.', null, $headers
+            $this->calculateRemainingAttempts($key, $maxAttempts),
+            $this->limiter->availableIn($key)
         );
     }
-
-    /**
-     * Get the number of seconds until the next retry.
-     *
-     * @param  string  $key
-     * @return int
-     */
-    protected function getTimeUntilNextRetry($key)
-    {
-        return $this->limiter->availableIn($key);
-    }
-
     /**
      * Add the limit header information to the given response.
      *
-     * @param  \Symfony\Component\HttpFoundation\Response  $response
-     * @param  int  $maxAttempts
-     * @param  int  $remainingAttempts
-     * @param  int|null  $retryAfter
-     * @return \Symfony\Component\HttpFoundation\Response
-     */
-    protected function addHeaders(Response $response, $maxAttempts, $remainingAttempts, $retryAfter = null)
-    {
-        $response->headers->add(
-            $this->getHeaders($maxAttempts, $remainingAttempts, $retryAfter)
-        );
-
-        return $response;
-    }
-
-    /**
-     * Get the limit headers information.
+     * @param  \Illuminate\Http\Response $response
+     * @param  int                       $maxAttempts
+     * @param  int                       $remainingAttempts
+     * @param  int|null                  $retryAfter
      *
-     * @param  int  $maxAttempts
-     * @param  int  $remainingAttempts
-     * @param  int|null  $retryAfter
-     * @return array
+     * @return \Illuminate\Http\Response
      */
-    protected function getHeaders($maxAttempts, $remainingAttempts, $retryAfter = null)
+    protected function addHeaders(\Symfony\Component\HttpFoundation\Response $response, $maxAttempts, $remainingAttempts, $retryAfter = null)
     {
         $headers = [
-            'X-RateLimit-Limit' => $maxAttempts,
+            'X-RateLimit-Limit'     => $maxAttempts,
             'X-RateLimit-Remaining' => $remainingAttempts,
         ];
-
-        if (! is_null($retryAfter)) {
+        if (!is_null($retryAfter)) {
             $headers['Retry-After'] = $retryAfter;
-            $headers['X-RateLimit-Reset'] = $this->availableAt($retryAfter);
         }
-
-        return $headers;
+        $response->headers->add($headers);
+        return $response;
     }
-
     /**
      * Calculate the number of remaining attempts.
      *
-     * @param  string  $key
-     * @param  int  $maxAttempts
-     * @param  int|null  $retryAfter
+     * @param  string $key
+     * @param  int    $maxAttempts
+     *
      * @return int
      */
-    protected function calculateRemainingAttempts($key, $maxAttempts, $retryAfter = null)
+    protected function calculateRemainingAttempts($key, $maxAttempts)
     {
-        if (is_null($retryAfter)) {
-            return $this->limiter->retriesLeft($key, $maxAttempts);
-        }
-
-        return 0;
+        return $this->limiter->retriesLeft($key, $maxAttempts);
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -27,6 +27,8 @@ $app = new Laravel\Lumen\Application(
 
 $app->withEloquent();
 
+// Routing
+$app->register(Appzcoder\LumenRoutesList\RoutesCommandServiceProvider::class);
 /*
 |--------------------------------------------------------------------------
 | Register Container Bindings

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -63,9 +63,10 @@ $app->singleton(
 //    App\Http\Middleware\ExampleMiddleware::class
 // ]);
 
-// $app->routeMiddleware([
+ $app->routeMiddleware([
 //     'auth' => App\Http\Middleware\Authenticate::class,
-// ]);
+     'throttle' => App\Http\Middleware\ThrottleRequests::class
+ ]);
 
 /*
 |--------------------------------------------------------------------------

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
     "require": {
         "php": ">=5.6.4",
         "laravel/lumen-framework": "5.5.*",
-        "vlucas/phpdotenv": "~2.2"
+        "vlucas/phpdotenv": "~2.2",
+        "appzcoder/lumen-routes-list": "^1.0"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,50 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "d7ca23bfe3adecc3beda85d197db4a0b",
+    "content-hash": "52189c3e5f35c53cf32d39e23056c16e",
     "packages": [
+        {
+            "name": "appzcoder/lumen-routes-list",
+            "version": "v1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/appzcoder/lumen-route-list.git",
+                "reference": "4d6a1452849dabecc148e2663fa5cb29d5516c84"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/appzcoder/lumen-route-list/zipball/4d6a1452849dabecc148e2663fa5cb29d5516c84",
+                "reference": "4d6a1452849dabecc148e2663fa5cb29d5516c84",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "~5.0",
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Appzcoder\\LumenRoutesList\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sohel Amin",
+                    "email": "sohelamincse@gmail.com",
+                    "homepage": "http://www.appzcoder.com"
+                }
+            ],
+            "description": "Display the route list of Lumen",
+            "keywords": [
+                "lumen",
+                "route list"
+            ],
+            "time": "2017-09-22T05:31:37+00:00"
+        },
         {
             "name": "doctrine/inflector",
             "version": "v1.3.0",

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,7 +16,7 @@
 //    return $router->app->version();
 //});
 
-$router->group(['middleware' => 'throttle:3,1'], function () use ($router) {
+$router->group(['middleware' => 'throttle:10,1'], function () use ($router) {
     $router->get('/', function () use ($router) {
         return view('index');
     });

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+
 /*
 |--------------------------------------------------------------------------
 | Application Routes
@@ -15,8 +16,10 @@
 //    return $router->app->version();
 //});
 
-$router->get('/',function() use ($router) {
-    return view('index');
+$router->group(['middleware' => 'throttle:3,1'], function () use ($router) {
+    $router->get('/', function () use ($router) {
+        return view('index');
+    });
 });
 
 $router->group(['prefix' => 'api'], function() use ($router){


### PR DESCRIPTION
### 何を解決するのか

大量のリクエストに対してレートミリットをかける為に`Throttle`を導入します。

### 詳細

- ここから参考にして調整した。
  - [hasib32/rest-api-with-lumen ThrottleRequests.php](https://github.com/hasib32/rest-api-with-lumen/blob/master/app/Http/Middleware/ThrottleRequests.php)

ここの記事も参考にした。
http://mikhailkozlov.com/blog/2016/02/29/request_rate_limiting_in_lumen_5/

### レビューポイント

(レビュアーに pull request のレビューのポイントを書きます)

### レビュアー

(pull request のレビュアーを決めてメンションします)

### 期限

(日にちや時間で指定。もしくは、速orゆっくりかを書きます)
